### PR TITLE
Fix play navigation, prevent duplicate dialog buttons, and clear shuffled state on reset

### DIFF
--- a/src/main/java/br/gm/cards/FinishController.java
+++ b/src/main/java/br/gm/cards/FinishController.java
@@ -66,6 +66,7 @@ public class FinishController {
         confirmButton.setOnAction((ActionEvent event) -> {
 
             if (yes.isSelected()) {
+                deck.clearShuffled();
                 deck.removeAll();
             } else if (no.isSelected()) {
                 deck.shuffle();

--- a/src/main/java/br/gm/cards/FristOpenController.java
+++ b/src/main/java/br/gm/cards/FristOpenController.java
@@ -50,7 +50,9 @@ public class FristOpenController {
         dialog.setTitle("Remove Card");
         dialog.setHeaderText("Remove a card from your deck");
 
-        dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        if (!dialog.getDialogPane().getButtonTypes().contains(ButtonType.CANCEL)) {
+            dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        }
         dialog.getDialogPane().setContent(createRemoveCardDialog());
         dialog.showAndWait();
     }
@@ -59,7 +61,9 @@ public class FristOpenController {
         dialog.setTitle("Add Card");
         dialog.setHeaderText("Add a card to your deck");
 
-        dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        if (!dialog.getDialogPane().getButtonTypes().contains(ButtonType.CANCEL)) {
+            dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        }
         dialog.getDialogPane().setContent(createAddCardDialog());
         dialog.showAndWait();
     }

--- a/src/main/java/br/gm/cards/HomeController.java
+++ b/src/main/java/br/gm/cards/HomeController.java
@@ -133,7 +133,9 @@ public class HomeController {
         dialog.setTitle("Add Card");
         dialog.setHeaderText("Add a card to your deck");
 
-        dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        if (!dialog.getDialogPane().getButtonTypes().contains(ButtonType.CANCEL)) {
+            dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        }
         dialog.getDialogPane().setContent(createAddCardDialog());
         dialog.showAndWait();
     }
@@ -166,7 +168,9 @@ public class HomeController {
         dialog.setTitle("Remove Card");
         dialog.setHeaderText("Remove a card from your deck");
 
-        dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        if (!dialog.getDialogPane().getButtonTypes().contains(ButtonType.CANCEL)) {
+            dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+        }
         dialog.getDialogPane().setContent(createRemoveCardDialog());
         dialog.showAndWait();
     }

--- a/src/main/java/br/gm/cards/PlayController.java
+++ b/src/main/java/br/gm/cards/PlayController.java
@@ -11,10 +11,8 @@ import javafx.scene.text.Text;
 
 public class PlayController {
 
-    boolean allReadyShowQuestion = false;
-    int page = 0;
-    int index = 0;
-    static boolean fristRun = true;
+    private boolean showingQuestion = true;
+    private int currentCardIndex = 0;
 
     @FXML
     private Button backButton;
@@ -36,44 +34,29 @@ public class PlayController {
 
     @FXML
     void back(ActionEvent event) {
-
-        System.out.println("page: " + page);
-        System.out.println("index: " + index);
-
-        if (index >= 1) {
-            page--;
-            index--;
-            allReadyShowQuestion = !allReadyShowQuestion;
-
-            if (allReadyShowQuestion) {
-                backButton.setDisable(false);
-                changeText.setText(deck.getPergunta(page));
-                numberText.setText(page + " / " + deck.size());
-            } else {
-                backButton.setDisable(false);
-                changeText.setText(deck.getResposta(index));
-                numberText.setText((page + 1) + " / " + deck.size());
+        if (showingQuestion) {
+            if (currentCardIndex == 0) {
+                backButton.setDisable(true);
+                return;
             }
-        } else if (index < 0) {
-            backButton.setDisable(true);
+
+            currentCardIndex--;
+            showingQuestion = false;
+        } else {
+            showingQuestion = true;
         }
+
+        updateCardView();
     }
 
     @FXML
     public void initialize() {
-
-        System.out.println("page: " + page);
-        System.out.println("index: " + index);
-
         tipText.setText("Number of Cards");
-        numberText.setText(page + " / " + deck.size());
+        currentCardIndex = 0;
+        showingQuestion = true;
 
-        changeText.setText(deck.getPergunta(page));
+        updateCardView();
         changeText.setOpacity(1);
-
-        allReadyShowQuestion = true;
-
-        backButton.setDisable(true);
     }
 
     @FXML
@@ -83,26 +66,30 @@ public class PlayController {
 
     @FXML
     void next(ActionEvent event) throws IOException {
-        System.out.println("page: " + page);
-        System.out.println("index: " + index);
+        if (showingQuestion) {
+            showingQuestion = false;
+            updateCardView();
+            return;
+        }
 
-        if (page >= deck.size()) {
+        currentCardIndex++;
+        if (currentCardIndex >= deck.size()) {
             changeScene(event, "finish.fxml");
             return;
         }
 
-        if (allReadyShowQuestion) {
-            backButton.setDisable(false);
-            changeText.setText(deck.getResposta(index));
-            numberText.setText((page + 1) + " / " + deck.size());
-            index++;
-            page++;
-            allReadyShowQuestion = false;
+        showingQuestion = true;
+        updateCardView();
+    }
+
+    private void updateCardView() {
+        backButton.setDisable(currentCardIndex == 0 && showingQuestion);
+        numberText.setText((currentCardIndex + 1) + " / " + deck.size());
+
+        if (showingQuestion) {
+            changeText.setText(deck.getPergunta(currentCardIndex));
         } else {
-            backButton.setDisable(false);
-            changeText.setText(deck.getPergunta(page));
-            numberText.setText(page + " / " + deck.size());
-            allReadyShowQuestion = true;
+            changeText.setText(deck.getResposta(currentCardIndex));
         }
     }
 


### PR DESCRIPTION
### Motivation
- Fix inconsistent Back/Next flow and off-by-one display during study sessions by simplifying the play-state model. 
- Prevent dialogs from accumulating duplicate `Cancel` buttons when reused. 
- Ensure the deck’s shuffled state is cleared when the deck is reset to avoid inconsistent behavior after reset. 

### Description
- Reworked `PlayController` to use a single `currentCardIndex` and a `showingQuestion` boolean and added `updateCardView()` to centralize UI updates, replacing the previous `page/index` logic. 
- Added guards in `HomeController` and `FristOpenController` to only add `ButtonType.CANCEL` when it is not already present on the dialog: `if (!dialog.getDialogPane().getButtonTypes().contains(ButtonType.CANCEL)) { ... }`. 
- Updated `FinishController` reset flow to call `deck.clearShuffled()` before `deck.removeAll()` to clear shuffled state. 
- Adjusted card position display to use `(currentCardIndex + 1) + " / " + deck.size()` so numbering is user-facing (1-based). 

### Testing
- Ran `git diff --check` to validate whitespace/merge issues; it succeeded. 
- Ran `mvn test -q`, but execution was blocked by an external dependency resolution error: Maven Central returned `403 Forbidden` while resolving `maven-resources-plugin`, so full test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ebf0f01e48327a08ea9a5d71e59da)